### PR TITLE
Rétablissement du fonctionnement de la card avec les nouvelles versions de l'integration + gestion themes clair/sombre + optimisations cosmétiques

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,18 @@
+
+# Change Log
+
+## v1.1
+
+- Compatibilité rétablie avec l'intégration de [Cyr-ius](https://github.com/Cyr-ius/hass-heatzy) suite aux modifications introduites avec la v5.8.3 du 25/10/2023.
+- Gestion des profils "mode clair" ou "mode sombre" de Home Assistant et adaptation des couleurs en fonction du profil en cours d'utilisation.
+- Adaptation du choix des icônes et des couleurs afin de ressembler davantage à l'application officielle heatzy.
+
+Merci à @luke7101 pour sa super PR!
+
+| Light mode   | Dark mode   |
+|--------------|-------------|
+| ![image](https://github.com/luke7101/heatzy-pilote-card/assets/58976540/e4106ff2-c398-4e55-a047-58b646473269) | ![image](https://github.com/luke7101/heatzy-pilote-card/assets/58976540/c1d26695-07cc-4d59-8086-3e655fa1a93c) |
+
+## v1.0
+
+- Compatibilité avec l'intégration Heatzy de [Devotics](https://github.com/Devotics/heatzy-home-hassistant).

--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
 # Heatzy Pilote Card
-[![HACS Supported](https://img.shields.io/badge/HACS-Not_Supported-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
+[![HACS Supported](https://img.shields.io/badge/HACS-Not_Supported-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
 Cette card est basée sur l'intégration de [Cyr-ius](https://github.com/Cyr-ius/hass-heatzy)
 
-# Ce qu'apporte ce fork
-
-- Compatibilité rétablie avec l'intégration de Cyr-ius suite aux modifications introduites avec la v5.8.3 du 25/10/2023.
-- Gestion des profils "mode clair" ou "mode sombre" de Home Assistant et adaptation des couleurs en fonction du profil en cours d'utilisation.
-- Adaptation du choix des icônes et des couleurs afin de ressembler davantage à l'application officielle heatzy.
-
-| Light mode       | Dark mode   | 
-| ---------- | ------ |
-| ![image](https://github.com/luke7101/heatzy-pilote-card/assets/58976540/e4106ff2-c398-4e55-a047-58b646473269)     | ![image](https://github.com/luke7101/heatzy-pilote-card/assets/58976540/c1d26695-07cc-4d59-8086-3e655fa1a93c) |
-
-
-# Installation
+## Installation
 
 Copiez `heatzy-pilote-card.js` dans `config/www/community/heatzy-pilote-card` (créer le dossier si besoin), ensuite ajoutez la ressource dans Home Assistant.
 Rendez-vous [ici](https://my.home-assistant.io/redirect/lovelace_dashboards/) pour ouvrir la configuration des tableaux de bord et cliquez sur les trois petits points en haut à droite et cliquez "Ressources".
@@ -24,29 +13,26 @@ Sur cette page vous pouvez ajouter une nouvelle ressource en cliquant sur le bou
 Remarque :
 A chaque fois que vous voulez remplacer ou mettre à jour le fichier heatzy-pilote-card.js il vous faudra incrémenter le numéro de version spécifié dans l'URL de la ressource afin qu'Home Assistant le prenne en compte ex : `/local/community/heatzy-pilote-card/heatzy-pilote-card.js?v=2.0.1`
 
-
-# Configuration de la carte
+## Configuration de la carte
 
 ### Main Options
 
-| Name       | Type   | Default      | Supported options           | Description |
-| ---------- | ------ | ------------ | --------------------------- | ----------------------------------- |
-| `type`     | string | **Required** | `custom:heatzy-pilote-card` | Type of the card  |
-| `title`    | string | optional     | none                        | Optional title in the header  |
-| `language` | string | EN           | EN\|FR                      | Language  |
-| `elements` | array  | **Required** | none                        | List of elements 
-
+| Name       | Type   | Default      | Supported options           | Description                  |
+|------------|--------|--------------|-----------------------------|------------------------------|
+| `type`     | string | **Required** | `custom:heatzy-pilote-card` | Type of the card             |
+| `title`    | string | optional     | none                        | Optional title in the header |
+| `language` | string | EN           | EN\|FR                      | Language                     |
+| `elements` | array  | **Required** | none                        | List of elements
 
 ### Options for Elements
 
-| Name | Type | Default | Supported options | Description |
-| ---------- | ------ | ------------ | --------------------------- | ----------------------------------- |
-| `entity`| string | **Required** | none | A `climate` entity, likely from [Devotics](https://github.com/Devotics/heatzy-home-hassistant) integration |
-| `friendly_name`| string | optional | the ID of the entity, minus `climate.`, capitalized | Name of the entity  |
-| `temp_sensor`| string | optional | none | Optional sensor to display the temperature of the room 
+| Name            | Type   | Default      | Supported options   | Description   |
+|-----------------|--------|--------------|------------------   |---------------|
+| `entity`        | string | **Required** | none                | A `climate` entity, likely from [Devotics](https://github.com/Devotics/heatzy-home-hassistant) integration |
+| `friendly_name` | string | optional     | the ID of the entity, minus `climate.`, capitalized | Name of the entity |
+| `temp_sensor`   | string | optional     | none                | Optional sensor to display the temperature of the room
 
-
-### Example 
+### Example
 
 ```yaml
 type: custom:heatzy-pilote-card

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Cette card est basée sur l'intégration de [Cyr-ius](https://github.com/Cyr-ius
 # Ce qu'apporte ce fork
 
 - Compatibilité rétablie avec l'intégration de Cyr-ius suite aux modifications introduites avec la v5.8.3 du 25/10/2023.
-
 - Gestion des profils "mode clair" ou "mode sombre" de Home Assistant et adaptation des couleurs en fonction du profil en cours d'utilisation.
-
 - Adaptation du choix des icônes et des couleurs afin de ressembler davantage à l'application officielle heatzy.
 
 | Light mode       | Dark mode   | 
@@ -19,12 +17,12 @@ Cette card est basée sur l'intégration de [Cyr-ius](https://github.com/Cyr-ius
 
 # Installation
 
-Copiez `heatzy-pilote-card.js` dans `config/www/community/heatzy-pilote-card` (créer le dossier si besoin), ensuite ajoutez la ressource dans Home Assitant.
-Rendez-vous [ici](https://my.home-assistant.io/redirect/lovelace_dashboards/) pour ouvrir la configuration des tableaux de bord et cliquez sur les trois petits point en hauit à droite et cliquez "Ressources".
+Copiez `heatzy-pilote-card.js` dans `config/www/community/heatzy-pilote-card` (créer le dossier si besoin), ensuite ajoutez la ressource dans Home Assistant.
+Rendez-vous [ici](https://my.home-assistant.io/redirect/lovelace_dashboards/) pour ouvrir la configuration des tableaux de bord et cliquez sur les trois petits points en haut à droite et cliquez "Ressources".
 Sur cette page vous pouvez ajouter une nouvelle ressource en cliquant sur le bouton "Ajouter ressource", il faudra ensuite spécifier l'URL `/local/community/heatzy-pilote-card/heatzy-pilote-card.js?v=2.0.0` et le type de ressource "Javascript".
 
-Annotation:
-A chaque fois que vous voulez remplacer ou mettre à jour le fichier heatzy-pilote-card.js il vous faudra incrementer le numéro de version spécifié dans l'URL de la ressource afin qu'Home Assistant le prenne en compte ex: `/local/community/heatzy-pilote-card/heatzy-pilote-card.js?v=2.0.1`
+Remarque :
+A chaque fois que vous voulez remplacer ou mettre à jour le fichier heatzy-pilote-card.js il vous faudra incrémenter le numéro de version spécifié dans l'URL de la ressource afin qu'Home Assistant le prenne en compte ex : `/local/community/heatzy-pilote-card/heatzy-pilote-card.js?v=2.0.1`
 
 
 # Configuration de la carte

--- a/README.md
+++ b/README.md
@@ -2,22 +2,30 @@
 [![HACS Supported](https://img.shields.io/badge/HACS-Not_Supported-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
 
-Cette card est basée sur l'intégration de [Devotics](https://github.com/Devotics/heatzy-home-hassistant).
+Cette card est basée sur l'intégration de [Cyr-ius](https://github.com/Cyr-ius/hass-heatzy)
+
+# Ce qu'apporte ce fork
+
+- Compatibilité rétablie avec l'intégration de Cyr-ius suite aux modifications introduites avec la v5.8.3 du 25/10/2023.
+
+- Gestion des profils "mode clair" ou "mode sombre" de Home Assistant et adaptation des couleurs en fonction du profil en cours d'utilisation.
+
+- Adaptation du choix des icônes et des couleurs afin de ressembler davantage à l'application officielle heatzy.
+
+| Light mode       | Dark mode   | 
+| ---------- | ------ |
+| ![image](https://github.com/luke7101/heatzy-pilote-card/assets/58976540/e4106ff2-c398-4e55-a047-58b646473269)     | ![image](https://github.com/luke7101/heatzy-pilote-card/assets/58976540/c1d26695-07cc-4d59-8086-3e655fa1a93c) |
+
 
 # Installation
 
-Copier `heatzy-pilote-card.js` dans `config/www/community/heatzy-pilote-card` (créer le dossier si besoin). Ensuite, dans `config.yaml`, ajouter un module de ressources comme ceci:
+Copiez `heatzy-pilote-card.js` dans `config/www/community/heatzy-pilote-card` (créer le dossier si besoin), ensuite ajoutez la ressource dans Home Assitant.
+Rendez-vous [ici](https://my.home-assistant.io/redirect/lovelace_dashboards/) pour ouvrir la configuration des tableaux de bord et cliquez sur les trois petits point en hauit à droite et cliquez "Ressources".
+Sur cette page vous pouvez ajouter une nouvelle ressource en cliquant sur le bouton "Ajouter ressource", il faudra ensuite spécifier l'URL `/local/community/heatzy-pilote-card/heatzy-pilote-card.js?v=2.0.0` et le type de ressource "Javascript".
 
-```yaml
-lovelace:
-  mode: yaml
-  resources:
-    - url: /hacsfiles/heatzy-pilote-card/heatzy-pilote-card.js
-      type: module
-```
+Annotation:
+A chaque fois que vous voulez remplacer ou mettre à jour le fichier heatzy-pilote-card.js il vous faudra incrementer le numéro de version spécifié dans l'URL de la ressource afin qu'Home Assistant le prenne en compte ex: `/local/community/heatzy-pilote-card/heatzy-pilote-card.js?v=2.0.1`
 
-Intégration à HACS à venir.
-Tuto en français : https://hacf.fr/installer-ajouter-integrations-customisations-avec-hacs/
 
 # Configuration de la carte
 
@@ -43,15 +51,11 @@ Tuto en français : https://hacf.fr/installer-ajouter-integrations-customisation
 ### Example 
 
 ```yaml
-type: 'custom:heatzy-pilote-card'
+type: custom:heatzy-pilote-card
 title: Mes chauffages
 language: fr
 elements:
-  - entity: climate.bureau
-    temp_sensor: sensor.temperature_bureau
-    friendly_name: Le Bureau
+  - entity: climate.rad_bureau
+    temp_sensor: sensor.bureau_temperature
+    friendly_name: Bureau
 ```
-
-![image](https://user-images.githubusercontent.com/15105152/102015208-7b4e1d80-3d5a-11eb-97f1-5b79b32d4da6.png)
-
-

--- a/heatzy-pilote-card.js
+++ b/heatzy-pilote-card.js
@@ -8,11 +8,16 @@ import {
 const translation = {
   en: {
     modes: {
-      "none": "None",
+      "none": "Off",
       "away": "Away",
       "eco": "Eco",
       "comfort": "Comfort"
-    }
+    },
+	hvacmodes: {
+	  "auto": "Sched",
+	  "off": "Off",
+	  "heat": "On"
+	}
   },
   fr: {
     modes: {
@@ -20,16 +25,43 @@ const translation = {
       "away": "Hors-gel",
       "eco": "Eco",
       "comfort": "Confort"
-    }
+    },
+	hvacmodes: {
+	  "auto": "Prog",
+	  "off": "Off",
+	  "heat": "On"
+	}
   }
 };
 
+const MODES = [ // https://cdn.materialdesignicons.com/7.1.96/
+    {name:"none", icon:"mdi:minus-circle", style:"heat_selected_none"}, 
+    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort"},
+    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco"}, 
+    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away"}	
+];
 
-const MODES = [ // https://cdn.materialdesignicons.com/5.3.45/
-    {name:"none", icon:"mdi:do-not-disturb"}, 
-    {name:"away", icon:"mdi:snowflake"},
-    {name:"eco", icon:"mdi:leaf"}, 
-    {name:"comfort", icon:"mdi:white-balance-sunny"} 
+// heat modes for darkMode
+const MODES_dark = [ // https://cdn.materialdesignicons.com/7.1.96/
+    {name:"none", icon:"mdi:minus-circle", style:"heat_selected_none_dark"}, 
+    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort_dark"},
+    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco_dark"}, 
+    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away_dark"}
+];
+
+const HVACMODES = [ // https://cdn.materialdesignicons.com/7.1.96/
+    {name:"off", icon:"mdi:minus-circle", style:"heat_selected_none"}, 
+    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort"},
+    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco"}, 
+    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away"}	
+];
+
+// heat modes for darkMode
+const HVACMODES_dark = [ // https://cdn.materialdesignicons.com/7.1.96/
+    {name:"off", icon:"mdi:minus-circle", style:"heat_selected_none_dark"},
+    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort_dark"},
+    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco_dark"}, 
+    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away_dark"}
 ];
 
 class HeatzyPiloteCard extends LitElement {
@@ -48,42 +80,96 @@ class HeatzyPiloteCard extends LitElement {
 
   _getTitle() {    
     if(this.config.title){
-      return html`<h1 class="card-header">${this.config.title}</h1>`;
+      return html`<h2 class="card-header">${this.config.title}</h2>`;
     }
     return html``;
   }
   
   _getContent(){
     return this.config.elements.map(elt => {
+	  const darkMode = this.hass.themes.darkMode;
       const ent = elt.entity;
       const name = elt.friendly_name ? elt.friendly_name : this._inferName(ent);
       const temp = this._getTemperature(elt.temp_sensor, 1);
       const stateObj = this.hass.states[ent];
-      const preset_mode = stateObj.attributes.preset_mode;
+	  const hvac_mode = stateObj.state // off, auto, heat
+      const hvac_action = stateObj.attributes.hvac_action; // off, heating
+	  const preset_mode = stateObj.attributes.preset_mode; // (null), comfort, eco, away
       const preset_mode_tr = this._getPresetModeTranslation(preset_mode);
-      return stateObj ?
-        html`<div class="state">      
-          <h2 class="heat_name">${name} ${temp}</h2>    
-          <span class="heat_icon_list">
-            ${preset_mode_tr} ${this._getIconList(MODES, preset_mode, stateObj.entity_id)}
-          </span>
-        </div>`:
-        html`<div class="not-found">Entity '${ent}' not found.</div>`;
-    });
+      const hvac_mode_tr = this._getHvacModeTranslation(hvac_mode);
+		if(darkMode==true){
+		  if(hvac_mode!='off'){
+			  return stateObj ?
+				html`<div class="state">      
+				  <h4 class="heat_name">${name} ${temp}</h4>    
+				  <span class="heat_icon_list">
+					${preset_mode_tr} ${this._getIconList(MODES_dark, preset_mode, stateObj.entity_id)}
+				  </span>
+				</div>`:
+				html`<div class="not-found">Entity '${ent}' not found.</div>`;
+		  }
+		  else{
+			  return stateObj ?
+				html`<div class="state">      
+				  <h4 class="heat_name">${name} ${temp}</h4>    
+				  <span class="heat_icon_list">
+					${hvac_mode_tr} ${this._getIconList(HVACMODES_dark, hvac_mode, stateObj.entity_id)}
+				  </span>
+				</div>`:
+				html`<div class="not-found">Entity '${ent}' not found.</div>`;
+		  }
+		}
+		if(darkMode!=true){
+		  if(hvac_mode!='off'){
+			  return stateObj ?
+				html`<div class="state">      
+				  <h4 class="heat_name">${name} ${temp}</h4>    
+				  <span class="heat_icon_list">
+					${preset_mode_tr} ${this._getIconList(MODES, preset_mode, stateObj.entity_id)}
+				  </span>
+				</div>`:
+				html`<div class="not-found">Entity '${ent}' not found.</div>`;
+		  }
+		  else{
+			  return stateObj ?
+				html`<div class="state">      
+				  <h4 class="heat_name">${name} ${temp}</h4>    
+				  <span class="heat_icon_list">
+					${hvac_mode_tr} ${this._getIconList(HVACMODES, hvac_mode, stateObj.entity_id)}
+				  </span>
+				</div>`:
+				html`<div class="not-found">Entity '${ent}' not found.</div>`;
+		  }
+		}
+	});
   }
 
   _getIconList(modes_list, mode_selected, entity_id){
       return modes_list.map(x => {
-          x.heat_class=x.name==mode_selected?'heat_selected':'';
-          const xx = html`<ha-icon class="heat_icon ${x.heat_class}" icon="${x.icon}" 
-                           @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
-          return(xx);
+		  const darkMode = this.hass.themes.darkMode;
+		  if(darkMode==true){
+			  x.heat_class=x.name==mode_selected?x.style:'';
+			  const xx = html`<ha-icon class="heat_icon_dark ${x.heat_class}" icon="${x.icon}" 
+							   @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
+			  return(xx);
+		  }
+		  if(darkMode!=true){
+			  x.heat_class=x.name==mode_selected?x.style:'';
+			  const xx = html`<ha-icon class="heat_icon ${x.heat_class}" icon="${x.icon}" 
+							   @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
+			  return(xx);
+		  }
       });
   }
   
   _getPresetModeTranslation(preset_mode){
     const language = this.config.language;
     return translation[language].modes[preset_mode];
+  }
+  
+  _getHvacModeTranslation(hvac_mode){
+    const language = this.config.language;
+    return translation[language].hvacmodes[hvac_mode];
   }
   
   _inferName(x){
@@ -94,7 +180,7 @@ class HeatzyPiloteCard extends LitElement {
   
   _getTemperature(sensor, digits){
     const temp = this.hass.states[sensor];
-    if(sensor!=undefined && temp==undefined){ //sensor in unknrown
+    if(sensor!=undefined && temp==undefined){ //sensor in unknown
       return(html`(?°C)`);
     }
     
@@ -106,25 +192,35 @@ class HeatzyPiloteCard extends LitElement {
   }
 
 
-  _handleClick(entity_id, preset_mode) {
-    this.hass.callService('climate', 'set_preset_mode', {
-      entity_id: entity_id,
-      preset_mode: preset_mode
-    });
+  _handleClick(entity_id, clicked_mode) {
+	  if(clicked_mode=='none'){
+		this.hass.callService('climate', 'set_hvac_mode', {
+		  entity_id: entity_id,
+		  hvac_mode: 'off'
+        });  
+	  }
+	  else {
+		this.hass.callService('climate', 'set_preset_mode', {
+		  entity_id: entity_id,
+		  preset_mode: clicked_mode
+        });  
+	  }
   }
   
   
   _getWarnings() {    
     const elts = this.config.elements
         
-    //check: entity is a climate with a "preset mode" attribute
+    //check: entity is a climate with a "preset mode" attribute / ajouté si hvac_action off
     for (let i=0; i<elts.length; i++){
       const elt = elts[i];
       const entity = this.hass.states[elt.entity];
-      if(entity.attributes.preset_mode==undefined){
-        const name = elt.friendly_name? html`("${elt.friendly_name}") ` : html``;
-        return html`<hui-warning>Entity "${elt.entity}" of element #${i+1} ${name}is not a climate entity with a "preset_mode" attribute</hui-warning>`;
-      }
+		if(entity.attributes.hvac_action!='off'){
+		  if(entity.attributes.preset_mode==undefined){
+			const name = elt.friendly_name? html`("${elt.friendly_name}") ` : html``;
+			return html`<hui-warning>Entity "${elt.entity}" of element #${i+1} ${name}is not a climate entity with a "preset_mode" attribute</hui-warning>`;
+		  };
+		}
     }
     
     //check: temperature sensor is not unknown
@@ -167,7 +263,8 @@ class HeatzyPiloteCard extends LitElement {
   getCardSize() {
     return this.config.elements.length + 1;
   }
-  
+
+// CSS styles for light/dark modes  
   static get styles() {
     return css`
         .state {
@@ -186,6 +283,16 @@ class HeatzyPiloteCard extends LitElement {
             margin:0;
             margin-left:25px;
         }
+        
+        .state h3 {
+            margin:0;
+            margin-left:15px;
+        }
+        
+        .state h4 {
+            margin:0;
+            margin-left:15px;
+        }
 
         .heat_icon_list {
             float:right;
@@ -203,8 +310,37 @@ class HeatzyPiloteCard extends LitElement {
         .heat_selected{
             color: green !important;
         }
+        .heat_selected_none{
+            color: #003333 !important;
+        }
+        .heat_selected_away{
+            color: #3366CC !important;
+        }
+        .heat_selected_eco{
+            color: #003333 !important;
+        }
+        .heat_selected_comfort{
+            color: #CC3333 !important;
+        }
+        .heat_selected_none_dark{
+            color: #cecece !important;
+        }
+        .heat_selected_away_dark{
+            color: #488FC2 !important;
+        }
+        .heat_selected_eco_dark{
+            color: #0F9D58 !important;
+        }
+        .heat_selected_comfort_dark{
+            color: #CC3333 !important;
+        }
         .heat_icon{
-            color: grey;
+            color: #CCCCCC;
+            cursor: pointer;
+            margin-left: 10px;
+        }
+        .heat_icon_dark{
+            color: #6F6F6F;
             cursor: pointer;
             margin-left: 10px;
         }

--- a/heatzy-pilote-card.js
+++ b/heatzy-pilote-card.js
@@ -159,8 +159,7 @@ class HeatzyPiloteCard extends LitElement {
         entity_id: entity_id,
         hvac_mode: 'off'
       });
-    }
-    else {
+    } else {
       this.hass.callService('climate', 'set_preset_mode', {
         entity_id: entity_id,
         preset_mode: clicked_mode

--- a/heatzy-pilote-card.js
+++ b/heatzy-pilote-card.js
@@ -41,14 +41,6 @@ const MODES = [ // https://cdn.materialdesignicons.com/7.1.96/
     {name:"away", icon:"mdi:snowflake", style:"heat_selected_away"}	
 ];
 
-// heat modes for darkMode
-const MODES_dark = [ // https://cdn.materialdesignicons.com/7.1.96/
-    {name:"none", icon:"mdi:minus-circle", style:"heat_selected_none_dark"}, 
-    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort_dark"},
-    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco_dark"}, 
-    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away_dark"}
-];
-
 const HVACMODES = [ // https://cdn.materialdesignicons.com/7.1.96/
     {name:"off", icon:"mdi:minus-circle", style:"heat_selected_none"}, 
     {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort"},
@@ -57,12 +49,9 @@ const HVACMODES = [ // https://cdn.materialdesignicons.com/7.1.96/
 ];
 
 // heat modes for darkMode
-const HVACMODES_dark = [ // https://cdn.materialdesignicons.com/7.1.96/
-    {name:"off", icon:"mdi:minus-circle", style:"heat_selected_none_dark"},
-    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort_dark"},
-    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco_dark"}, 
-    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away_dark"}
-];
+const MODES_dark = MODES.map(({...x}) => {x.style = x.style+"_dark"; return x })
+const HVACMODES_dark = HVACMODES.map(({...x}) => {x.style = x.style+"_dark"; return x })
+
 
 class HeatzyPiloteCard extends LitElement {
 

--- a/heatzy-pilote-card.js
+++ b/heatzy-pilote-card.js
@@ -92,11 +92,11 @@ class HeatzyPiloteCard extends LitElement {
       let modeSelected;
       if (hvac_mode != 'off') {
         translation = hvac_mode_tr;
-        modeList = darkMode? MODES_dark : MODES;
+        modeList = darkMode ? MODES_dark : MODES;
         modeSelected = preset_mode;
       } else {
         translation = preset_mode_tr;
-        modeList =  darkMode? HVACMODES_dark : HVACMODES;
+        modeList = darkMode ? HVACMODES_dark : HVACMODES;
         modeSelected = hvac_mode;
       };
       return stateObj ?
@@ -113,18 +113,13 @@ class HeatzyPiloteCard extends LitElement {
   _getIconList(modes_list, mode_selected, entity_id) {
     return modes_list.map(x => {
       const darkMode = this.hass.themes.darkMode;
-      if (darkMode == true) {
-        x.heat_class = x.name == mode_selected ? x.style : '';
-        const xx = html`<ha-icon class="heat_icon_dark ${x.heat_class}" icon="${x.icon}" 
-							   @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
-        return (xx);
-      }
-      if (darkMode != true) {
-        x.heat_class = x.name == mode_selected ? x.style : '';
-        const xx = html`<ha-icon class="heat_icon ${x.heat_class}" icon="${x.icon}" 
-							   @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
-        return (xx);
-      }
+      x.heat_class = x.name == mode_selected ? 'heat_selected' : '';
+      const classSelected = x.name == mode_selected ? x.style : x.heat_class;
+      const classDark = darkMode ? "heat_icon_dark" : "heat_icon";
+
+      const xx = html`<ha-icon class="${classDark} ${classSelected}" icon="${x.icon}" 
+      @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
+      return (xx);
     });
   }
 

--- a/heatzy-pilote-card.js
+++ b/heatzy-pilote-card.js
@@ -86,50 +86,27 @@ class HeatzyPiloteCard extends LitElement {
       const preset_mode = stateObj.attributes.preset_mode; // (null), comfort, eco, away
       const preset_mode_tr = this._getPresetModeTranslation(preset_mode);
       const hvac_mode_tr = this._getHvacModeTranslation(hvac_mode);
-      if (darkMode == true) {
-        if (hvac_mode != 'off') {
-          return stateObj ?
-            html`<div class="state">      
-				  <h4 class="heat_name">${name} ${temp}</h4>    
-				  <span class="heat_icon_list">
-					${preset_mode_tr} ${this._getIconList(MODES_dark, preset_mode, stateObj.entity_id)}
-				  </span>
-				</div>`:
-            html`<div class="not-found">Entity '${ent}' not found.</div>`;
-        }
-        else {
-          return stateObj ?
-            html`<div class="state">      
-				  <h4 class="heat_name">${name} ${temp}</h4>    
-				  <span class="heat_icon_list">
-					${hvac_mode_tr} ${this._getIconList(HVACMODES_dark, hvac_mode, stateObj.entity_id)}
-				  </span>
-				</div>`:
-            html`<div class="not-found">Entity '${ent}' not found.</div>`;
-        }
-      }
-      if (darkMode != true) {
-        if (hvac_mode != 'off') {
-          return stateObj ?
-            html`<div class="state">      
-				  <h4 class="heat_name">${name} ${temp}</h4>    
-				  <span class="heat_icon_list">
-					${preset_mode_tr} ${this._getIconList(MODES, preset_mode, stateObj.entity_id)}
-				  </span>
-				</div>`:
-            html`<div class="not-found">Entity '${ent}' not found.</div>`;
-        }
-        else {
-          return stateObj ?
-            html`<div class="state">      
-				  <h4 class="heat_name">${name} ${temp}</h4>    
-				  <span class="heat_icon_list">
-					${hvac_mode_tr} ${this._getIconList(HVACMODES, hvac_mode, stateObj.entity_id)}
-				  </span>
-				</div>`:
-            html`<div class="not-found">Entity '${ent}' not found.</div>`;
-        }
-      }
+
+      let translation;
+      let modeList;
+      let modeSelected;
+      if (hvac_mode != 'off') {
+        translation = hvac_mode_tr;
+        modeList = darkMode? MODES_dark : MODES;
+        modeSelected = preset_mode;
+      } else {
+        translation = preset_mode_tr;
+        modeList =  darkMode? HVACMODES_dark : HVACMODES;
+        modeSelected = hvac_mode;
+      };
+      return stateObj ?
+        html`<div class="state">      
+          <h4 class="heat_name">${name} ${temp}</h4>    
+          <span class="heat_icon_list">
+          ${translation} ${this._getIconList(modeList, modeSelected, stateObj.entity_id)}
+          </span>
+        </div>`:
+        html`<div class="not-found">Entity '${ent}' not found.</div>`;
     });
   }
 

--- a/heatzy-pilote-card.js
+++ b/heatzy-pilote-card.js
@@ -13,11 +13,11 @@ const translation = {
       "eco": "Eco",
       "comfort": "Comfort"
     },
-	hvacmodes: {
-	  "auto": "Sched",
-	  "off": "Off",
-	  "heat": "On"
-	}
+    hvacmodes: {
+      "auto": "Sched",
+      "off": "Off",
+      "heat": "On"
+    }
   },
   fr: {
     modes: {
@@ -26,36 +26,36 @@ const translation = {
       "eco": "Eco",
       "comfort": "Confort"
     },
-	hvacmodes: {
-	  "auto": "Prog",
-	  "off": "Off",
-	  "heat": "On"
-	}
+    hvacmodes: {
+      "auto": "Prog",
+      "off": "Off",
+      "heat": "On"
+    }
   }
 };
 
 const MODES = [ // https://cdn.materialdesignicons.com/7.1.96/
-    {name:"none", icon:"mdi:minus-circle", style:"heat_selected_none"}, 
-    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort"},
-    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco"}, 
-    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away"}	
+  { name: "none", icon: "mdi:minus-circle", style: "heat_selected_none" },
+  { name: "comfort", icon: "mdi:white-balance-sunny", style: "heat_selected_comfort" },
+  { name: "eco", icon: "mdi:weather-night", style: "heat_selected_eco" },
+  { name: "away", icon: "mdi:snowflake", style: "heat_selected_away" }
 ];
 
 const HVACMODES = [ // https://cdn.materialdesignicons.com/7.1.96/
-    {name:"off", icon:"mdi:minus-circle", style:"heat_selected_none"}, 
-    {name:"comfort", icon:"mdi:white-balance-sunny", style:"heat_selected_comfort"},
-    {name:"eco", icon:"mdi:weather-night", style:"heat_selected_eco"}, 
-    {name:"away", icon:"mdi:snowflake", style:"heat_selected_away"}	
+  { name: "off", icon: "mdi:minus-circle", style: "heat_selected_none" },
+  { name: "comfort", icon: "mdi:white-balance-sunny", style: "heat_selected_comfort" },
+  { name: "eco", icon: "mdi:weather-night", style: "heat_selected_eco" },
+  { name: "away", icon: "mdi:snowflake", style: "heat_selected_away" }
 ];
 
 // heat modes for darkMode
-const MODES_dark = MODES.map(({...x}) => {x.style = x.style+"_dark"; return x })
-const HVACMODES_dark = HVACMODES.map(({...x}) => {x.style = x.style+"_dark"; return x })
+const MODES_dark = MODES.map(({ ...x }) => { x.style = x.style + "_dark"; return x })
+const HVACMODES_dark = HVACMODES.map(({ ...x }) => { x.style = x.style + "_dark"; return x })
 
 
 class HeatzyPiloteCard extends LitElement {
 
-  render() { 
+  render() {
     return html`
         <ha-card>
             ${this._getTitle()}           
@@ -67,185 +67,185 @@ class HeatzyPiloteCard extends LitElement {
     `;
   }
 
-  _getTitle() {    
-    if(this.config.title){
+  _getTitle() {
+    if (this.config.title) {
       return html`<h2 class="card-header">${this.config.title}</h2>`;
     }
     return html``;
   }
-  
-  _getContent(){
+
+  _getContent() {
     return this.config.elements.map(elt => {
-	  const darkMode = this.hass.themes.darkMode;
+      const darkMode = this.hass.themes.darkMode;
       const ent = elt.entity;
       const name = elt.friendly_name ? elt.friendly_name : this._inferName(ent);
       const temp = this._getTemperature(elt.temp_sensor, 1);
       const stateObj = this.hass.states[ent];
-	  const hvac_mode = stateObj.state // off, auto, heat
+      const hvac_mode = stateObj.state // off, auto, heat
       const hvac_action = stateObj.attributes.hvac_action; // off, heating
-	  const preset_mode = stateObj.attributes.preset_mode; // (null), comfort, eco, away
+      const preset_mode = stateObj.attributes.preset_mode; // (null), comfort, eco, away
       const preset_mode_tr = this._getPresetModeTranslation(preset_mode);
       const hvac_mode_tr = this._getHvacModeTranslation(hvac_mode);
-		if(darkMode==true){
-		  if(hvac_mode!='off'){
-			  return stateObj ?
-				html`<div class="state">      
+      if (darkMode == true) {
+        if (hvac_mode != 'off') {
+          return stateObj ?
+            html`<div class="state">      
 				  <h4 class="heat_name">${name} ${temp}</h4>    
 				  <span class="heat_icon_list">
 					${preset_mode_tr} ${this._getIconList(MODES_dark, preset_mode, stateObj.entity_id)}
 				  </span>
 				</div>`:
-				html`<div class="not-found">Entity '${ent}' not found.</div>`;
-		  }
-		  else{
-			  return stateObj ?
-				html`<div class="state">      
+            html`<div class="not-found">Entity '${ent}' not found.</div>`;
+        }
+        else {
+          return stateObj ?
+            html`<div class="state">      
 				  <h4 class="heat_name">${name} ${temp}</h4>    
 				  <span class="heat_icon_list">
 					${hvac_mode_tr} ${this._getIconList(HVACMODES_dark, hvac_mode, stateObj.entity_id)}
 				  </span>
 				</div>`:
-				html`<div class="not-found">Entity '${ent}' not found.</div>`;
-		  }
-		}
-		if(darkMode!=true){
-		  if(hvac_mode!='off'){
-			  return stateObj ?
-				html`<div class="state">      
+            html`<div class="not-found">Entity '${ent}' not found.</div>`;
+        }
+      }
+      if (darkMode != true) {
+        if (hvac_mode != 'off') {
+          return stateObj ?
+            html`<div class="state">      
 				  <h4 class="heat_name">${name} ${temp}</h4>    
 				  <span class="heat_icon_list">
 					${preset_mode_tr} ${this._getIconList(MODES, preset_mode, stateObj.entity_id)}
 				  </span>
 				</div>`:
-				html`<div class="not-found">Entity '${ent}' not found.</div>`;
-		  }
-		  else{
-			  return stateObj ?
-				html`<div class="state">      
+            html`<div class="not-found">Entity '${ent}' not found.</div>`;
+        }
+        else {
+          return stateObj ?
+            html`<div class="state">      
 				  <h4 class="heat_name">${name} ${temp}</h4>    
 				  <span class="heat_icon_list">
 					${hvac_mode_tr} ${this._getIconList(HVACMODES, hvac_mode, stateObj.entity_id)}
 				  </span>
 				</div>`:
-				html`<div class="not-found">Entity '${ent}' not found.</div>`;
-		  }
-		}
-	});
+            html`<div class="not-found">Entity '${ent}' not found.</div>`;
+        }
+      }
+    });
   }
 
-  _getIconList(modes_list, mode_selected, entity_id){
-      return modes_list.map(x => {
-		  const darkMode = this.hass.themes.darkMode;
-		  if(darkMode==true){
-			  x.heat_class=x.name==mode_selected?x.style:'';
-			  const xx = html`<ha-icon class="heat_icon_dark ${x.heat_class}" icon="${x.icon}" 
+  _getIconList(modes_list, mode_selected, entity_id) {
+    return modes_list.map(x => {
+      const darkMode = this.hass.themes.darkMode;
+      if (darkMode == true) {
+        x.heat_class = x.name == mode_selected ? x.style : '';
+        const xx = html`<ha-icon class="heat_icon_dark ${x.heat_class}" icon="${x.icon}" 
 							   @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
-			  return(xx);
-		  }
-		  if(darkMode!=true){
-			  x.heat_class=x.name==mode_selected?x.style:'';
-			  const xx = html`<ha-icon class="heat_icon ${x.heat_class}" icon="${x.icon}" 
+        return (xx);
+      }
+      if (darkMode != true) {
+        x.heat_class = x.name == mode_selected ? x.style : '';
+        const xx = html`<ha-icon class="heat_icon ${x.heat_class}" icon="${x.icon}" 
 							   @click="${e => this._handleClick(entity_id, x.name)}"></ha-icon>`;
-			  return(xx);
-		  }
-      });
+        return (xx);
+      }
+    });
   }
-  
-  _getPresetModeTranslation(preset_mode){
+
+  _getPresetModeTranslation(preset_mode) {
     const language = this.config.language;
     return translation[language].modes[preset_mode];
   }
-  
-  _getHvacModeTranslation(hvac_mode){
+
+  _getHvacModeTranslation(hvac_mode) {
     const language = this.config.language;
     return translation[language].hvacmodes[hvac_mode];
   }
-  
-  _inferName(x){
+
+  _inferName(x) {
     x = x.replace("climate.", "");
-    return x.charAt(0).toUpperCase() + x.slice(1); 
+    return x.charAt(0).toUpperCase() + x.slice(1);
   }
-  
-  
-  _getTemperature(sensor, digits){
+
+
+  _getTemperature(sensor, digits) {
     const temp = this.hass.states[sensor];
-    if(sensor!=undefined && temp==undefined){ //sensor in unknown
-      return(html`(?°C)`);
+    if (sensor != undefined && temp == undefined) { //sensor in unknown
+      return (html`(?°C)`);
     }
-    
-    if(sensor){
+
+    if (sensor) {
       const temperature = parseFloat(temp.state).toFixed(digits);
-      return(html`(${temperature}${temp.attributes.unit_of_measurement})`);
-    } 
-    return(html``);
+      return (html`(${temperature}${temp.attributes.unit_of_measurement})`);
+    }
+    return (html``);
   }
 
 
   _handleClick(entity_id, clicked_mode) {
-	  if(clicked_mode=='none'){
-		this.hass.callService('climate', 'set_hvac_mode', {
-		  entity_id: entity_id,
-		  hvac_mode: 'off'
-        });  
-	  }
-	  else {
-		this.hass.callService('climate', 'set_preset_mode', {
-		  entity_id: entity_id,
-		  preset_mode: clicked_mode
-        });  
-	  }
+    if (clicked_mode == 'none') {
+      this.hass.callService('climate', 'set_hvac_mode', {
+        entity_id: entity_id,
+        hvac_mode: 'off'
+      });
+    }
+    else {
+      this.hass.callService('climate', 'set_preset_mode', {
+        entity_id: entity_id,
+        preset_mode: clicked_mode
+      });
+    }
   }
-  
-  
-  _getWarnings() {    
+
+
+  _getWarnings() {
     const elts = this.config.elements
-        
+
     //check: entity is a climate with a "preset mode" attribute / ajouté si hvac_action off
-    for (let i=0; i<elts.length; i++){
+    for (let i = 0; i < elts.length; i++) {
       const elt = elts[i];
       const entity = this.hass.states[elt.entity];
-		if(entity.attributes.hvac_action!='off'){
-		  if(entity.attributes.preset_mode==undefined){
-			const name = elt.friendly_name? html`("${elt.friendly_name}") ` : html``;
-			return html`<hui-warning>Entity "${elt.entity}" of element #${i+1} ${name}is not a climate entity with a "preset_mode" attribute</hui-warning>`;
-		  };
-		}
-    }
-    
-    //check: temperature sensor is not unknown
-    for (let i=0; i<elts.length; i++){
-      const elt = elts[i];
-      const temp = this.hass.states[elt.temp_sensor];
-      if(elt.temp_sensor!=undefined && temp==undefined){
-        const name = elt.friendly_name? html`("${elt.friendly_name}") ` : html``;
-        return html`<hui-warning>Sensor "${elt.temp_sensor}" of element #${i+1} ${name}is unknown</hui-warning>`;
+      if (entity.attributes.hvac_action != 'off') {
+        if (entity.attributes.preset_mode == undefined) {
+          const name = elt.friendly_name ? html`("${elt.friendly_name}") ` : html``;
+          return html`<hui-warning>Entity "${elt.entity}" of element #${i + 1} ${name}is not a climate entity with a "preset_mode" attribute</hui-warning>`;
+        };
       }
     }
-    
+
+    //check: temperature sensor is not unknown
+    for (let i = 0; i < elts.length; i++) {
+      const elt = elts[i];
+      const temp = this.hass.states[elt.temp_sensor];
+      if (elt.temp_sensor != undefined && temp == undefined) {
+        const name = elt.friendly_name ? html`("${elt.friendly_name}") ` : html``;
+        return html`<hui-warning>Sensor "${elt.temp_sensor}" of element #${i + 1} ${name}is unknown</hui-warning>`;
+      }
+    }
+
     return html``;
   }
-  
+
   setConfig(config) {
     //elements must be defined
     if (!config.elements) {
       throw new Error("You need to define elements");
     }
-    
+
     //each element must have an entity
-    for (let i=0; i<config.elements.length;i++){
+    for (let i = 0; i < config.elements.length; i++) {
       const elt = config.elements[i];
       if (!elt.entity) {
-        throw new Error("You need to define a climate entity for element #"+i);
+        throw new Error("You need to define a climate entity for element #" + i);
       }
-    }    
-    
+    }
+
     //translation is supported
-    if(config.language == undefined){
+    if (config.language == undefined) {
       config.language = "en"
-    } else if(translation[config.language]==undefined){
+    } else if (translation[config.language] == undefined) {
       throw new Error(`Supported languages are only ["en", "fr"]. "${config.language}" is not a supported language.`);
     }
-    
+
     this.config = config;
   }
 
@@ -253,7 +253,7 @@ class HeatzyPiloteCard extends LitElement {
     return this.config.elements.length + 1;
   }
 
-// CSS styles for light/dark modes  
+  // CSS styles for light/dark modes  
   static get styles() {
     return css`
         .state {


### PR DESCRIPTION
### Contributions

- Compatibilité rétablie avec l'intégration de Cyr-ius suite aux modifications introduites avec la v5.8.3 du 25/10/2023.
- Gestion des profils "mode clair" ou "mode sombre" de Home Assistant et adaptation des couleurs en fonction du profil en cours d'utilisation.
- Adaptation du choix des icônes et des couleurs afin de ressembler davantage à l'application officielle heatzy.
- Màj readme avec notice d'installation de la card correspondant à la version actuelle de HA

